### PR TITLE
feat(images): update ghcr.io/k8s-at-home/qbittorrent docker tag to v4.4.0

### DIFF
--- a/cluster/apps/media/qbittorrent/helm-release.yaml
+++ b/cluster/apps/media/qbittorrent/helm-release.yaml
@@ -34,7 +34,7 @@ spec:
           privileged: true
     image:
       repository: ghcr.io/k8s-at-home/qbittorrent
-      tag: v4.3.9
+      tag: v4.4.0
     env:
       TZ: "${TZ}"
     service:


### PR DESCRIPTION
Reverts 0dragosh/homelab-k3s#722