### PR TITLE
Revert "fix(images): update ghcr.io/k8s-at-home/plex docker tag to v1.25.3.5409-f11334058"

### DIFF
--- a/cluster/apps/media/plex/helm-release.yaml
+++ b/cluster/apps/media/plex/helm-release.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     image:
       repository: ghcr.io/k8s-at-home/plex
-      tag: v1.25.3.5409-f11334058
+      tag: v1.25.3.5385-f05b712b6
     env:
       TZ: "${TZ}"
     podSecurityContext:


### PR DESCRIPTION
Reverts 0dragosh/homelab-k3s#736