### PR TITLE
Fix renovate regex manager for external-dns crds

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -107,7 +107,7 @@
         "cluster/crds/external-dns/.+\\.yaml$"
       ],
       "matchStrings": [
-        "datasource=(?<datasource>.*?)\n *url: https:\/\/github\\.com\/(?<depName>.*?)\\.git\n *ref:\n *tag: (?<currentValue>.*)\n"
+        "url: https:\/\/github\\.com\/(?<depName>.*?)\\.git\n *ref:\n *tag: (?<currentValue>.*)\n"
       ],
       "datasourceTemplate": "github-releases"
     }


### PR DESCRIPTION
**Description of the change**

Update renovate regex managers config for external-dns crds

**Benefits**

Renovate will be able to update external-dns crds version.

**Applicable issues**

Renovate does not create MR for updating external-dns crds.

